### PR TITLE
Improved OWCF tests robustness

### DIFF
--- a/calc2DWeights.jl
+++ b/calc2DWeights.jl
@@ -304,6 +304,20 @@ else
 end
 
 ## ---------------------------------------------------------------------------------------------
+# Python code (load Python packages for DRESS code)
+# This is how you write Python code in Julia: py""" [Python code] """
+verbose && println("Loading Python modules... ")
+@everywhere begin
+    py"""
+    import os.path
+    import numpy as np
+    import forward
+    import spec
+    import vcone
+    """
+end
+
+## ---------------------------------------------------------------------------------------------
 # If available, load instrumental response and process it accordingly
 global instrumental_response # Declare global scope
 instrumental_response = false
@@ -512,20 +526,6 @@ println("")
 println("Written by Henrik Järleblad. Last maintained 2025-05-23.")
 println("--------------------------------------------------------------------------------------------------")
 println("")
-
-## ---------------------------------------------------------------------------------------------
-# Python code (essentially calling the forward model black box)
-# This is how you write Python code in Julia: py""" [Python code] """
-verbose && println("Loading Python modules... ")
-@everywhere begin
-    py"""
-    import os.path
-    import numpy as np
-    import forward
-    import spec
-    import vcone
-    """
-end
 
 ## ---------------------------------------------------------------------------------------------
 # If no thermal distribution file was specified, and default temp. and dens. profiles were specified,

--- a/calc4DWeights.jl
+++ b/calc4DWeights.jl
@@ -122,7 +122,7 @@
 # WARNING! Please note that the output files of calc4DWeights.jl will be LARGE. This is due to the relatively high dimensionality
 # of the weight functions.
 
-# Script written by Henrik Järleblad. Last maintained 2025-05-29.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ################################################################################################
 
 ## ---------------------------------------------------------------------------------------------
@@ -130,6 +130,8 @@ verbose && println("Loading Julia packages... ")
 @everywhere begin
     cd(folderpath_OWCF) # Necessary to move all the workers to the correct folder
     using PyCall # For using Python code in Julia
+    using Printf # To be able to print specific formats
+    plot_results && (using Plots)
     include("misc/species_func.jl") # To map particle species labels to particle mass etc
     include("misc/availReacts.jl") # To examine fusion reaction and extract thermal and fast-ion species
     include("misc/rewriteReacts.jl") # To rewrite a fusion reaction from e.g. the a(b,c)d format to the a-b=c-d format

--- a/extra/createCustomLOS.jl
+++ b/extra/createCustomLOS.jl
@@ -260,7 +260,7 @@ elseif case==4
     detector_location_y = detector_location[1]*sin(detector_location[2]*pi/180)
     detector_location = [detector_location_x, detector_location_y, detector_location[3]] # Cartesian
 else # case must be 5
-    verbose && println("LOS specified as angle w.r.t. the magnetic field. Computing (x,y,z) LOS vecotrs... ")
+    verbose && println("LOS specified as angle w.r.t. the magnetic field. Computing (x,y,z) LOS vector... ")
     # The most complicated one...
     if R_of_interest==:mag_axis
         R_of_interest = magnetic_axis(M)[1]
@@ -275,7 +275,7 @@ else # case must be 5
         error("z_of_interest specified incorrectly! Please correct and re-try.")
     end
     B_vec = Bfield(M, R_of_interest, z_of_interest)
-    R = getRotationMatrix([0.0,1.0,0.0], LOS_vec[1] *(pi/180)) # Get a rotation matrix that can rotate any vector θ_u degrees
+    R = getRotationMatrix([1.0,0.0,0.0], LOS_vec[1] *(pi/180)) # Get a rotation matrix that can rotate any vector θ_u degrees
     b_vec = B_vec ./ norm(B_vec)
     LOS_vec = R*b_vec # Rotate B-field unit vector θ_u degrees around the y_axis to get LOS_vec with θ_u degrees relative to B-field
 
@@ -668,7 +668,7 @@ if plot_LOS
     end
 
     plt_crs = Plots.heatmap(flux_R, flux_z, transpose(LOS_Rz_proj), title="Poloidal proj. $(LOS_name) LOS", fillcolor=cgrad(color_array, categorical=true), colorbar=false)
-    plt_crs = Plots.contour!(flux_R, flux_z, transpose(psi_rz), levels=collect(range(psi_mag, stop=psi_bdry,length=7)), color=:lightgray, clims=clims, linewidth=2.5, label="", colorbar=false)
+    plt_crs = Plots.contour!(flux_R, flux_z, transpose(psi_rz), levels=collect(range(psi_mag, stop=psi_bdry,length=7)), color=:gray, clims=clims, linewidth=2.5, label="", colorbar=false, α=0.5)
     plt_crs = Plots.plot!(wall.r,wall.z,label="Tokamak first wall",linewidth=2.5,color=:black)
     #plt_crs = Plots.scatter!([detector_location_R],[detector_location[3]], label="Detector location", markershape=:star, markercolor=:purple, markerstrokewidth=2)
     plt_crs = Plots.scatter!([magnetic_axis(M)[1]],[magnetic_axis(M)[2]],label="Mag. axis",markershape=:xcross,markercolor=:red,markerstrokewidth=4)

--- a/tests/run_tests.jl
+++ b/tests/run_tests.jl
@@ -3,7 +3,7 @@
 # PLEASE NOTE!! THIS SCRIPT AND RELATED SCRIPTS ARE CURRENTLY UNDER DEVELOPMENT!!!
 # PLEASE NOTE!! THIS SCRIPT AND RELATED SCRIPTS ARE CURRENTLY UNDER DEVELOPMENT!!!
 # PLEASE NOTE!! THIS SCRIPT AND RELATED SCRIPTS ARE CURRENTLY UNDER DEVELOPMENT!!!
-#
+
 ### Description:
 # This script will run all the tests of the OWCF, to ensure correct functionality. 
 # It will run all the start files in the folder OWCF/tests/start_files/. If no errors are produced,
@@ -24,38 +24,60 @@
 #      unless you include a screenshot of your test results with your pull-request. Your screenshot
 #      should clearly show that the execution of 'include("run_tests.jl")' resulted in 100% of the 
 #      tests completing successfully.
-#
+
 ### Inputs:
 # plot_test_results - If true, test results will be plotted and saved in .png file format - Bool
 # terminate_when_first_error - If true, as soon as an error is encountered, the error and stacktrace 
 #                              will be printed and the run_tests.jl script will terminate. If there 
 #                              are parts of the OWCF that have not yet been tested, these will be 
 #                              ignored, i.e. not tested - Bool
-# clear_test_outputs_folder_when_done - If true, the OWCF/tests/outputs/ folder will be cleared when 
-#                                  the run_tests.jl script has finished all tests. 'false' can be useful
-#                                  if test results are to be manually inspected in detail - Bool
+# clear_test_outputs_folder_when_done - If true, the OWCF/tests/outputs/ folder will be cleared and 
+#                                       deleted when the run_tests.jl script has finished all tests. 
+#                                       'false' can be useful if test results are to be manually 
+#                                       inspected in detail - Bool
 # VERY_VERBOSE - If true, all print statements from all individual tests will be printed to terminal.
 #                WARNING! The VERY_VERBOSE input variable SHOULD BE SET TO false, unless you are a 
 #                developer and debugging.
-#
+
 ### Outputs:
 # None, after run_tests.jl has completed. However, temporary output files are saved in the OWCF/
 # tests/outputs/ folder.
-#
+
 ### Other:
-# Please do NOT change anything (!) in the OWCF/tests/ folder. The results of the run_tests.jl 
+# Please do NOT change anything (!) in the OWCF/tests/ folder. The final results of the run_tests.jl 
 # script should be printed to terminal only. As explained above, if you are a developer, this
 # printed output should be included as a screenshot when creating a pull-request at the Github repo
 # https://github.com/JuliaFusion/OWCF/pulls.
+#
+# Finally, please note that the run_tests.jl script will produce several data files (and .png figure 
+# files, if plot_test_results==true). These will be saved in the OWCF/tests/outputs/ folder. The 
+# total size of all data files and .png figure files will be in the range of tens of megabytes.
 
-# Script written by Henrik Järleblad. Last mainted 2025-06-02.
+# Script written by Henrik Järleblad. Last mainted 2025-06-11.
 ###################################################################################################
 
-plot_test_results = false # If set to true, test results will be plotted and saved in .png file format in the OWCF/tests/outputs/ folder
+# Inputs. To be switched freely between 'true' and 'false'
+plot_test_results = false # If set to true, results of the individual tests will be plotted and saved as .png files in the OWCF/tests/outputs/ folder
 terminate_when_first_error = false # If set to true, the run_tests.jl script will print the first error it encounters and skip the rest of the testing process
 clear_test_outputs_folder_when_done = true # Should be set to true, be default
 VERY_VERBOSE = false # Should be set to false, unless developer debugging
 
+###------------------------------------------------------------------------------------------------###
+###-------------------------------------- START OF TESTS ------------------------------------------###
+###----------------------- PLEASE DO NOT ALTER ANYTHING BELOW THESE LINES! ------------------------###
+###------------------------------------------------------------------------------------------------###
+###------------------------------------------------------------------------------------------------###
+###-------------------------------------- START OF TESTS ------------------------------------------###
+###----------------------- PLEASE DO NOT ALTER ANYTHING BELOW THESE LINES! ------------------------###
+###------------------------------------------------------------------------------------------------###
+###------------------------------------------------------------------------------------------------###
+###-------------------------------------- START OF TESTS ------------------------------------------###
+###----------------------- PLEASE DO NOT ALTER ANYTHING BELOW THESE LINES! ------------------------###
+###------------------------------------------------------------------------------------------------###
+###------------------------------------------------------------------------------------------------###
+###-------------------------------------- START OF TESTS ------------------------------------------###
+###----------------------- PLEASE DO NOT ALTER ANYTHING BELOW THESE LINES! ------------------------###
+###------------------------------------------------------------------------------------------------###
 ###------------------------------------------------------------------------------------------------###
 ###-------------------------------------- START OF TESTS ------------------------------------------###
 ###----------------------- PLEASE DO NOT ALTER ANYTHING BELOW THESE LINES! ------------------------###
@@ -168,13 +190,15 @@ folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-1]))*"/" # We
 cd(folderpath_OWCF); using Pkg; Pkg.activate(".") # Navigate to the OWCF folder, activate the OWCF environment
 using Distributed # To enable test files of accessing the 'folderpath_OWCF' variable value correctly
 using Dates # To enable date and time functions use
-using JLD2 # To enable reading of test start files in .jld2 file format 
-plot_test_results && (using Plots) # If test results are to be plotted, the Plots.jl package needs to be loaded
+using FileIO # For writing error files
+
 oldstdout = stdout # To be able to suppress prints from the test scripts, but not errors
 oldstderr = stderr # To be able to suppress warnings from the test scripts, but not errors
 SUPPRESS_SUBTEST_PRINT = !VERY_VERBOSE
+###------------------------------------------------------------------------------------------------###
 
-# Checking so that the OWCF/tests/outputs/ folder is empty
+############---------------------------------------------------------------------------------------###
+# Checking that the OWCF/tests/outputs/ folder is empty
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
@@ -197,15 +221,46 @@ if !isempty(readdir(folderpath_OWCF*"tests/outputs/"))
         end
         println("Done!")
     else
-        error("The run_tests.jl script cannot be executed unless the $(folderpath_OWCF)tests/outputs/ is empty. Please empty it manually, and re-start run_tests.jl.")
+        error("The run_tests.jl script cannot be executed unless the $(folderpath_OWCF)tests/outputs/ folder is empty. Please empty the folder manually, and re-start run_tests.jl.")
     end
 end
+println("")
 
+# Checking that the OWCF/tests/errors/ folder is empty
+if !isdir(folderpath_OWCF*"tests/errors/")
+    print("The folder $(folderpath_OWCF)tests/errors/ does not exist. Creating... ")
+    mkdir(folderpath_OWCF*"tests/errors")
+    println("ok!")
+end
+if !isempty(readdir(folderpath_OWCF*"tests/errors/"))
+    num_o_files = length(readdir(folderpath_OWCF*"tests/errors/")); ff = num_o_files==1 ? "file" : "files"
+    println("The $(folderpath_OWCF)tests/errors/ folder was not empty ($(num_o_files) $(ff)).")
+    s = "q"
+    while !(lowercase(s)=="y" || lowercase(s)=="n")
+        global s
+        print("Remove all files in the $(folderpath_OWCF)tests/errors/ folder (y/n)? ")
+        s = readline()
+    end
+    if lowercase(s)=="y"
+        print("Removing all files in the $(folderpath_OWCF)tests/errors/ folder... ")
+        error_files = readdir(folderpath_OWCF*"tests/errors/")
+        for error_file in error_files
+            rm(folderpath_OWCF*"tests/errors/"*error_file)
+        end
+        println("Done!")
+    else
+        error("The run_tests.jl script cannot be executed unless the $(folderpath_OWCF)tests/errors/ folder is empty. Please empty the folder manually, and re-start run_tests.jl.")
+    end
+end
+println("")
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
 date_and_time = split("$(Dates.now())","T")[1]*" at "*split("$(Dates.now())","T")[2][1:5]
-test_list = readdir(folderpath_OWCF*"tests/start_files/") # All tests are in the OWCF/tests/start_files/ folder
+test_list = map(x-> "$(split(x,".")[1])", readdir(folderpath_OWCF*"tests/start_files/")) # All tests are in the OWCF/tests/start_files/ folder. Remove the ".jl" file extension
 NUMBER_OF_TESTS = length(test_list) # The total number of tests
+err_dict = Dict() # A dictionary to keep track of the test error file paths
 test_prog = 0 # An integer to keep track of testing progress
-err_dict = Dict() # A dictionary to keep track of which tests threw errors, and what the errors were
 ###------------------------------------------------------------------------------------------------###
 
 ############---------------------------------------------------------------------------------------###
@@ -217,41 +272,48 @@ println("-----------------------------------------------------------------------
 
 ############---------------------------------------------------------------------------------------###
 for test in test_list
-    global test_prog
+    global test_prog # Declare test_prog as the global test_prog variable defined already before (outside of) this for-loop
+    err_file = "$(folderpath_OWCF)tests/errors/$(test).err" # No global scope declaration needed, since err_file String will not be changed
+    err_IO = open(err_file,"w") # No global scope declaration needed, since the err_IO channel will not be changed (only used)
 
-    println("- Running $(test) (total run_tests.jl progress: $(Int64(round(100*test_prog/NUMBER_OF_TESTS)))%)... ")
+    println("- Running $(test).jl (total run_tests progress: $(Int64(round(100*test_prog/NUMBER_OF_TESTS)))%)... ")
 
     try
         SUPPRESS_SUBTEST_PRINT && redirect_stdout(devnull) # Re-direct prints to null
-        SUPPRESS_SUBTEST_PRINT && redirect_stderr(devnull) # Re-direct warnings to null
-        include(folderpath_OWCF*"tests/start_files/$(test)")
+        SUPPRESS_SUBTEST_PRINT && redirect_stderr(err_IO) # Re-direct warnings and errors to error output file
+        # By using Base.run(), we effectively reset the namespace and unload all Julia packages every time before each test start file is run
+        Base.run(`julia $(folderpath_OWCF*"tests/start_files/$(test).jl") plot_test_results $(plot_test_results)`)
     catch e
-        SUPPRESS_SUBTEST_PRINT && redirect_stderr(oldstderr) # Re-direct warnings back to old I/O channel (i.e. the default, visible channel)
+        SUPPRESS_SUBTEST_PRINT && redirect_stderr(oldstderr) # Re-direct warnings and errors back to old I/O channel (i.e. the default, visible terminal)
         global err_dict # Declare err_dict as the err_dict variable from the global scope (outside of the for-loop and the try-catch statement)
-        @warn "The test $(test) unfortunately resulted in an error. Please examine error specification when test results are printed."
-        err_dict["$(test)"] = "$(e)" # Save the error message to the err_dict Dictionary, with the test start file as key
+        @warn "The test $(test) unfortunately resulted in an error. Please examine the error and stack trace in $(err_file)"
+        err_dict["$(test)"] = "$(err_file)" # Save the error file path to the err_dict Dictionary, with the test start file as key
         terminate_when_first_error && redirect_stdout(oldstdout) # Re-direct prints back to old I/O channel (i.e. the default, visible channel)
+        terminate_when_first_error && close(err_IO) # If we break the for-loop immidiately below this line, close the error file I/O channel
         terminate_when_first_error && break # Break from the 'for test in test_list' for-loop
     end
 
+    close(err_IO) # If terminate_when_first_error==false, we need to close the error file I/O channel here
+    if !("$(test)" in keys(err_dict)) # If this test did not produce any errors...
+        rm(err_file) # To avoid confusion, remove the error file
+    end
+
     SUPPRESS_SUBTEST_PRINT && redirect_stdout(oldstdout) # Re-direct prints back to old I/O channel (i.e. the default, visible channel)
-    test_prog += 1 # Test completed!
+    test_prog += 1 # Test completed! Onto the next one!
 end
-println("- All tests completed (total run_tests.jl progress: $(round(100*test_prog/NUMBER_OF_TESTS,digits=3)) %)... ")
+println("- All tests completed (total run_tests.jl progress: $(Int64(round(100*test_prog/NUMBER_OF_TESTS)))%)... ")
 ###------------------------------------------------------------------------------------------------###
 
 ############---------------------------------------------------------------------------------------###
-# Removing all created files from the OWCF/tests/outputs/ folder
+# Removing all created files in the OWCF/tests/outputs/ folder, if requested
 println("--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------")
 if clear_test_outputs_folder_when_done
     print("- Clearing the OWCF/tests/outputs/ folder... ")
-    output_files = readdir(folderpath_OWCF*"tests/outputs/")
-    for output_file in output_files
-        rm(folderpath_OWCF*"tests/outputs/"*output_file)
-    end
+    rm(folderpath_OWCF*"tests/outputs/", recursive=true)
     println("Done!")
 else
-    println("- The $(folderpath_OWCF)tests/outputs/ folder contains all test output files. Please inspect files in folder prior to running run_tests.jl again.")
+    output_folder_size_in_megabytes = inv(1_000_000)*reduce(+, filesize.("$(folderpath_OWCF)tests/outputs/" .*readdir("$(folderpath_OWCF)tests/outputs/")))
+    println("- The $(folderpath_OWCF)tests/outputs/ folder contains all test output files. The total size of all test output files is approx. $(round(output_folder_size_in_megabytes, digits=1)) MB. Please inspect files in folder prior to running run_tests.jl again.")
 end
 ###------------------------------------------------------------------------------------------------###
 
@@ -263,20 +325,24 @@ println("- Printing test results... ")
 tot_number_o_errs = length(keys(err_dict))
 println("- Total number of errors: $(tot_number_o_errs)")
 if tot_number_o_errs==0
+    rm(folderpath_OWCF*"tests/errors/", recursive=true) # If no errors, to avoid confusion, clear and remove the OWCF/tests/errors/ folder
     println("- CONGRATULATIONS! The OWCF can be assumed to function correctly.")
     println("")
     println("---> IF YOU ARE A USER, please go ahead and safely use the OWCF. Enjoy!")
     println("---> IF YOU ARE A DEVELOPER, please attach a screenshot of the test results to your pull-request on Github, if you would like to merge your branch with the main OWCF branch.")
 else
-    println("- Printing error specification(s)... ")
+    s = tot_number_o_errs > 1 ? "s" : ""
+    println("- Please examine the error$(s) and stack trace$(s) in the following file$(s) (can be opened in the same way as .txt files)... ")
+    println("")
     for key in keys(err_dict)
-        println(" --->  $(key): $(err_dict[key]). To re-run this specific test, please do 'julia $(folderpath_OWCF*"tests/start_files/$(key)")'")
+        println(" --->  $(key): $(err_dict[key])")
+        println(" ------> To re-run only this specific test, please do (with 'b' set to either true or false) 'julia $(folderpath_OWCF*"tests/start_files/$(key).jl") plot_test_results b'")
         println("")
         println("")
     end
     println("")
     println("---> IF YOU ARE A USER, please post a new issue at https://github.com/JuliaFusion/OWCF/issues, attach the test results and describe your situation. Thank you!")
-    println("---> IF YOU ARE A DEVELOPER, please investigate the error(s) (the specific OWCF scripts and lines of code (integers) are specified above), fix the errors and re-run run-tests.jl.")
+    println("---> IF YOU ARE A DEVELOPER, please investigate the error$(s), fix the error$(s) and re-run run-tests.jl.")
 end
 ###------------------------------------------------------------------------------------------------###
 

--- a/tests/start_files/start_calc2DW_test1.jl
+++ b/tests/start_files/start_calc2DW_test1.jl
@@ -89,29 +89,56 @@
 # and thermal_dens_axis variables will be used to scale the polynomial profiles to match the specified
 # thermal temperature and thermal density at the magnetic axis. Please see the /misc/temp_n_dens.jl script for info.
 
-# Script written by Henrik Järleblad. Last maintained 2025-03-25.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ######################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed, even though distributed might be set to false. This is to export all inputs to all workers right away, if needed.
 #batch_job = false
 distributed = false
+
+############---------------------------------------------------------------------------------------###
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)
     Pkg.activate(".")
 end
+###------------------------------------------------------------------------------------------------###
+
 #numOcores = 4 # When executing script via HPC cluster job, make sure you know how many cores you have requested for your batch job
 
 ## Navigate to the OWCF folder and activate the OWCF environment

--- a/tests/start_files/start_calc2DW_test2.jl
+++ b/tests/start_files/start_calc2DW_test2.jl
@@ -89,29 +89,56 @@
 # and thermal_dens_axis variables will be used to scale the polynomial profiles to match the specified
 # thermal temperature and thermal density at the magnetic axis. Please see the /misc/temp_n_dens.jl script for info.
 
-# Script written by Henrik Järleblad. Last maintained 2025-03-25.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ######################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed, even though distributed might be set to false. This is to export all inputs to all workers right away, if needed.
 #batch_job = false
 distributed = false
+
+############---------------------------------------------------------------------------------------###
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)
     Pkg.activate(".")
 end
+###------------------------------------------------------------------------------------------------###
+
 #numOcores = 4 # When executing script via HPC cluster job, make sure you know how many cores you have requested for your batch job
 
 ## Navigate to the OWCF folder and activate the OWCF environment

--- a/tests/start_files/start_calc2DW_test3.jl
+++ b/tests/start_files/start_calc2DW_test3.jl
@@ -89,29 +89,56 @@
 # and thermal_dens_axis variables will be used to scale the polynomial profiles to match the specified
 # thermal temperature and thermal density at the magnetic axis. Please see the /misc/temp_n_dens.jl script for info.
 
-# Script written by Henrik Järleblad. Last maintained 2025-03-25.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ######################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed, even though distributed might be set to false. This is to export all inputs to all workers right away, if needed.
 #batch_job = false
 distributed = false
+
+############---------------------------------------------------------------------------------------###
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)
     Pkg.activate(".")
 end
+###------------------------------------------------------------------------------------------------###
+
 #numOcores = 4 # When executing script via HPC cluster job, make sure you know how many cores you have requested for your batch job
 
 ## Navigate to the OWCF folder and activate the OWCF environment

--- a/tests/start_files/start_calc2DW_test4.jl
+++ b/tests/start_files/start_calc2DW_test4.jl
@@ -89,29 +89,56 @@
 # and thermal_dens_axis variables will be used to scale the polynomial profiles to match the specified
 # thermal temperature and thermal density at the magnetic axis. Please see the /misc/temp_n_dens.jl script for info.
 
-# Script written by Henrik Järleblad. Last maintained 2025-03-25.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ######################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed, even though distributed might be set to false. This is to export all inputs to all workers right away, if needed.
 #batch_job = false
 distributed = false
+
+############---------------------------------------------------------------------------------------###
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)
     Pkg.activate(".")
 end
+###------------------------------------------------------------------------------------------------###
+
 #numOcores = 4 # When executing script via HPC cluster job, make sure you know how many cores you have requested for your batch job
 
 ## Navigate to the OWCF folder and activate the OWCF environment

--- a/tests/start_files/start_calcEpRzTopoMap_test1.jl
+++ b/tests/start_files/start_calcEpRzTopoMap_test1.jl
@@ -63,29 +63,56 @@
 #   FI_species - The fast-ion species. "D", "3he", "T" etc - String
 #   filepath_distr - If used, the filepath to the fast-ion distribution .jld2 file - String
 
-# Script written by Henrik Järleblad. Last maintained 2024-06-25.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ########################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed, even though distributed might be set to false. This is to export all inputs to all workers right away, if needed.
 batch_job = false
 distributed = false
+
+############---------------------------------------------------------------------------------------###
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)
     Pkg.activate(".")
 end
+###------------------------------------------------------------------------------------------------###
+
 #numOcores = 4 # When executing script via HPC cluster job, make sure you know how many cores you have requested for your batch job
 
 ## Navigate to the OWCF folder and activate the OWCF environment

--- a/tests/start_files/start_createCustomFIDistr_test1.jl
+++ b/tests/start_files/start_createCustomFIDistr_test1.jl
@@ -105,27 +105,53 @@
 #### Other
 # 
 
-# Script written by Henrik Järleblad. Last maintained 2025-04-24.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ################################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed to be loaded, even though multi-core computations are not needed for createCustomLOS.jl.
+
+############---------------------------------------------------------------------------------------###
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)
     Pkg.activate(".")
 end
+###------------------------------------------------------------------------------------------------###
 
 ### Navigate to the OWCF folder and activate the OWCF environment
 #cd(folderpath_OWCF)

--- a/tests/start_files/start_createCustomFIDistr_test2.jl
+++ b/tests/start_files/start_createCustomFIDistr_test2.jl
@@ -105,24 +105,47 @@
 #### Other
 # 
 
-# Script written by Henrik Järleblad. Last maintained 2025-04-24.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ################################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed to be loaded, even though multi-core computations are not needed for createCustomLOS.jl.
+
 ############---------------------------------------------------------------------------------------###
-# If running this script independently (not as a part of the OWCF/tests/run_tests.jl)
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)

--- a/tests/start_files/start_createCustomLOS_test1.jl
+++ b/tests/start_files/start_createCustomLOS_test1.jl
@@ -76,24 +76,47 @@
 #### Other
 # 
 
-# Script written by Henrik Järleblad. Last maintained 2025-06-02.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ######################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed to be loaded, even though multi-core computations are not needed for createCustomLOS.jl.
+
 ############---------------------------------------------------------------------------------------###
-# If running this script independently (not as a part of the OWCF/tests/run_tests.jl)
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)

--- a/tests/start_files/start_createCustomLOS_test2.jl
+++ b/tests/start_files/start_createCustomLOS_test2.jl
@@ -76,24 +76,47 @@
 #### Other
 # 
 
-# Script written by Henrik Järleblad. Last maintained 2025-03-26.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ######################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed to be loaded, even though multi-core computations are not needed for createCustomLOS.jl.
+
 ############---------------------------------------------------------------------------------------###
-# If running this script independently (not as a part of the OWCF/tests/run_tests.jl)
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)

--- a/tests/start_files/start_createCustomLOS_test3.jl
+++ b/tests/start_files/start_createCustomLOS_test3.jl
@@ -76,24 +76,47 @@
 #### Other
 # 
 
-# Script written by Henrik Järleblad. Last maintained 2025-03-26.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ######################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed to be loaded, even though multi-core computations are not needed for createCustomLOS.jl.
+
 ############---------------------------------------------------------------------------------------###
-# If running this script independently (not as a part of the OWCF/tests/run_tests.jl)
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)

--- a/tests/start_files/start_createCustomLOS_test4.jl
+++ b/tests/start_files/start_createCustomLOS_test4.jl
@@ -77,24 +77,47 @@
 # IF NOT SPECIFIED OTHERWISE, all angles in this start file should be specified in degrees, and points/lengths 
 # in meters.
 
-# Script written by Henrik Järleblad. Last maintained 2025-03-26.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ######################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed to be loaded, even though multi-core computations are not needed for createCustomLOS.jl.
+
 ############---------------------------------------------------------------------------------------###
-# If running this script independently (not as a part of the OWCF/tests/run_tests.jl)
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)

--- a/tests/start_files/start_createCustomLOS_test5.jl
+++ b/tests/start_files/start_createCustomLOS_test5.jl
@@ -77,24 +77,47 @@
 # IF NOT SPECIFIED OTHERWISE, all angles in this start file should be specified in degrees, and points/lengths 
 # in meters.
 
-# Script written by Henrik Järleblad. Last maintained 2025-03-26.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ######################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed to be loaded, even though multi-core computations are not needed for createCustomLOS.jl.
+
 ############---------------------------------------------------------------------------------------###
-# If running this script independently (not as a part of the OWCF/tests/run_tests.jl)
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)

--- a/tests/start_files/start_createCustomMagneticEquilibrium_test1.jl
+++ b/tests/start_files/start_createCustomMagneticEquilibrium_test1.jl
@@ -34,24 +34,47 @@
 #### Other
 # s
 
-# Script written by Henrik Järleblad. Last maintained 2025-04-14.
+# Script written by Henrik Järleblad. Last maintained 2025-06-11.
 ############################################################################################################################
 
 ## First you have to set the system specifications
 using Distributed # Needed to be loaded, even though multi-core computations are not needed for createCustomLOS.jl.
+
 ############---------------------------------------------------------------------------------------###
-# If running this script independently (not as a part of the OWCF/tests/run_tests.jl)
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
+###------------------------------------------------------------------------------------------------###
+
+############---------------------------------------------------------------------------------------###
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
     using Pkg
     cd(folderpath_OWCF)
@@ -59,7 +82,7 @@ end
 end
 ###------------------------------------------------------------------------------------------------###
 
-## -----------------------------------------------------------------------------
+############---------------------------------------------------------------------------------------###
 @everywhere begin
     B0 = 3.0 # Magnetic field on-axis. Tesla
     R0 = 3.0 # Major radius position of magnetic axis. Meters
@@ -82,7 +105,9 @@ end
     Ip_dir = -1 # By default, assume that the plasma current runs clockwise around the torus (viewed from above)
     diverted = true # By default, assume that the user would like a divertor
 end
+###------------------------------------------------------------------------------------------------###
 
-## -----------------------------------------------------------------------------
+############---------------------------------------------------------------------------------------###
 # Then you execute the script
 include(folderpath_OWCF*"extra/createCustomMagneticEquilibrium.jl")
+###------------------------------------------------------------------------------------------------###

--- a/tests/start_files/start_dependencies_tests.jl
+++ b/tests/start_files/start_dependencies_tests.jl
@@ -1,30 +1,60 @@
 ############---------------------------------------------------------------------------------------###
 # A script to test a lot of the tools in the OWCF/extra/dependencies.jl script
+# Written by Henrik Järleblad. Last maintained 2025-06-11
+###------------------------------------------------------------------------------------------------###
+
+# Load the Distributed package, for multi-CPU computing. Might be used in future multi-CPU testing
+using Distributed
+using Dates # For easily working with time and dates
+
+############---------------------------------------------------------------------------------------###
+# We need to thoroughly deduce if the user wants the 'plot_test_results' input variable to be true or false
+
+# First, check if the length of the Julia input arguments list is greater than 1
+if length(ARGS)>1
+    if "plot_test_results" in lowercase.(ARGS) # If the argument list contains the 'plot_test_results' input variable
+        # Assume that the boolean value for the 'plot_test_results' input variable is provided as the input argument directly after the 'plot_test_results' input argument
+        i_bool = findfirst(x-> x=="plot_test_results", lowercase.(ARGS))+1
+        try 
+            # Declare global scope. To be able to use the 'plot_test_results' input variable outside of this try-catch statement
+            global plot_test_results = parse(Bool, ARGS[i_bool])
+        catch
+            # If anything goes wrong, assume that the 'plot_test_results' input variable should be set to false
+            global plot_test_results = false
+        end
+    end
+elseif @isdefined plot_test_results # If not, check if the 'plot_test_results' variable has already been defined
+    plot_test_results = plot_test_results # Use that value (might have been set in a super script, with this script run via 'include("OWCF/start_files/start_..._test....jl")')
+else # If nothing else, assume that the 'plot_test_results' input variable should be set to false
+    plot_test_results = false
+end
 ###------------------------------------------------------------------------------------------------###
 
 ############---------------------------------------------------------------------------------------###
-# If running this script independently (not as a part of the OWCF/tests/run_tests.jl)
+# Define the folderpath_OWCF variable, if not already defined in a super script
 if !(@isdefined folderpath_OWCF)
     folderpath_OWCF = reduce(*,map(x-> "/"*x,split(@__DIR__,"/")[2:end-2]))*"/" # We know that the test start file is located in the OWCF/tests/start_files/ folder. Deduce the full OWCF folder path from that information
 end
-if !(@isdefined plot_test_results)
-    plot_test_results = false
-end
+# Create the OWCF/tests/outputs/ folder, if it does not already exist
 if !isdir(folderpath_OWCF*"tests/outputs/")
     print("The folder $(folderpath_OWCF)tests/outputs/ does not exist. Creating... ")
     mkdir(folderpath_OWCF*"tests/outputs")
     println("ok!")
 end
+# Change the working directory to the OWCF/ folder, and activate the OWCF Julia environment
 @everywhere begin
+    plot_test_results = $plot_test_results
+    
     using Pkg
     cd(folderpath_OWCF)
     Pkg.activate(".")
+
+    plot_test_results && (using Plots) # If plots of the test results are requested, load the Plots.jl package
 end
 ###------------------------------------------------------------------------------------------------###
 
 ############---------------------------------------------------------------------------------------###
 include(folderpath_OWCF*"extra/dependencies.jl")
-plot_test_results = plot_test_results # SET TO TRUE, VIA THE plot_test_results INPUT VARIABLE IN THE OWCF/tests/run_tests.jl SCRIPT
 ###------------------------------------------------------------------------------------------------###
 
 ############---------------------------------------------------------------------------------------###


### PR DESCRIPTION
Re-writing of the OWCF tests to run each individual test via `Base.run()` instead of `include()`. This ensures that each individual test only has access to its own variables and Julia packages. 

Further upgrades include
- Folder size info of the tests outputs folder
- Error files in errors folder, with error and full stack strace for each test
- Small bug fixes