### PR TITLE
Customizable regularization strength bounds

### DIFF
--- a/extra/dependencies.jl
+++ b/extra/dependencies.jl
@@ -23,7 +23,7 @@
 #
 # Finally, please note that some functions in dependencies.jl might be under construction. Hence, the bad code.
 #
-# Written by H. Järleblad. Last maintained 2025-07-17.
+# Written by H. Järleblad. Last maintained 2025-07-31.
 ###################################################################################################
 
 println("Loading the Julia packages for the OWCF dependencies... ")
@@ -4153,6 +4153,7 @@ function _slowing_down_function_core(v_0::Real, p_0::Real, v_array::Vector{T} wh
                                      species_f::String, species_th_vec::Vector{String}, n_th_vec::Vector{T} where {T<:Real}, T_th_vec::Vector{T} where {T<:Real}; 
                                      S0::Float64=1.0, g=(v-> v), dampen::Bool=false, damp_type::Symbol=:erfc, sigma::Union{Nothing,Real}=nothing, 
                                      v_damp::Union{Nothing,Real}=nothing, returnExtra::Bool=false)
+    p_0 = clamp(p_0, -0.999, 0.999) # Clamp the injection pitch, to avoid singularities at (-1.0, 1.0)
     m_e = (GuidingCenterOrbits.e_amu)*(GuidingCenterOrbits.mass_u) # Electron mass, kg
     τ_s = spitzer_slowdown_time(n_e, T_e, species_f, species_th_vec, n_th_vec, T_th_vec) # Spitzer slowing-down time, s
     Z_th_vec = getSpeciesEcu.(species_th_vec) # Atomic charge number for all thermal plasma ion species

--- a/templates/start_solveInverseProblem_template.jl
+++ b/templates/start_solveInverseProblem_template.jl
@@ -106,9 +106,8 @@
 #           filepaths_W will be used - Vector{Float64}
 # nr_array - A Vector of integer values to specify the number of grid points for the regularization strength (λ) for the regularization types included in the 
 #           'regularization' input Vector (please see below). length(nr_array)==length(regularization) must hold. Each Integer in nr_array is assumed to specify
-#           the number of λ grid points for the corresponding element in the 'regularization' input Vector. The lower and upper bounds of each λ are set 
-#           automatically. Some regularization types do not need a λ (e.g. :COLLISIONS). The corresponding element in nr_array will then be treated as a 
-#           dummy value. - Vector{Int64}
+#           the number of λ grid points for the corresponding element in the 'regularization' input Vector. Some regularization types do not need a λ 
+#           (e.g. :COLLISIONS). The corresponding element in nr_array will then be treated as a dummy value. - Vector{Int64}
 # noise_floor_factor - If the error (err) of the diagnostic measurements (S) has smaller values than noise_floor_factor*maximum(S), all such 
 #                      values will be lifted up (changed) to noise_floor_factor*maximum(S). - Float64
 # plot_solutions - If set to true, plots of the solutions to the inverse problems will be saved in .png format. As well as the 
@@ -124,6 +123,16 @@
 #                                as prior information when solving the inverse problem. Currently, this is only available for velocity-space (2D) reconstructions 
 #                                in (E,p) and (vpara,vperp), orbit-space reconstructions in (3D) (E,mu,Pphi), (E,Lambda,Pphi_n) and (3+1 D) (E,mu,Pphi,sigma), (E,Lambda,Pphi_n,sigma).
 #                  One or several of the above options should be specified as elements in a Vector. Otherwise, empty Vector - Vector{Symbol}
+# regularization_loglambda_mins - The lower bounds for the logarithm of the regularization strength (λ) for the regularization types included in the 'regularization' 
+#                              input Vector (please see above). length(regularization_loglambda_mins)==length(regularization) must hold. Each element in 
+#                              regularization_loglambda_mins is assumed to specify the lower bound for the log10(λ) grid points for the corresponding element in 
+#                              the 'regularization' input Vector. Some regularization types do not need a λ (e.g. :COLLISIONS). The corresponding element in 
+#                              regularization_loglambda_mins will then be treated as a dummy value - Vector{Float64}
+# regularization_loglambda_maxs - The upper bounds for the logarithm of the regularization strength (λ) for the regularization types included in the 'regularization' 
+#                              input Vector (please see above). length(regularization_loglambda_maxs)==length(regularization) must hold. Each element in 
+#                              regularization_loglambda_maxs is assumed to specify the upper bound for the log10(λ) grid points for the corresponding element in 
+#                              the 'regularization' input Vector. Some regularization types do not need a λ (e.g. :COLLISIONS). The corresponding element in 
+#                              regularization_loglambda_maxs will then be treated as a dummy value - Vector{Float64}
 # regularization_equil_filepath - If :COLLISIONS and/or :ICRF is included in the 'regularization' Vector, the filepath to a magnetic equilibrium file 
 #                                 (either in .eqdsk file format or an OWCF/extra/createCustomMagneticEquilibrium.jl output file) must be specified. For :COLLISIONS, this is to 
 #                                 compute necessary quantities for the creation of the slowing-down basis functions, e.g. the Spitzer slowing-down time.
@@ -283,6 +292,8 @@ Pkg.activate(".")
     plot_solutions = false
     nr_array = [20] # Should be equal in length to 'regularization'
     regularization = [:ZEROTIKHONOV] # Should be equal in length to 'nr_array'
+    regularization_loglambda_mins = [-3] # The minimum of log10(λ) in ||S-WF||+λ||LF|| for each regularization type in the 'regularization' input variable Vector
+    regularization_loglambda_maxs = [3] # The maximum of log10(λ) in ||S-WF||+λ||LF|| for each regularization type in the 'regularization' input variable Vector
     if (:COLLISIONS in regularization) || (:ICRF in regularization) # :COLLISIONS and/or :ICRF included in regularization...
         regularization_equil_filepath = "" # Please specify the file path to a magnetic equilibrium file (see template description above)
     end


### PR DESCRIPTION
New features:
- The user can now customize the bounds of each regularization parameter when using the solveInverseProblem.jl tool
- Improved robustness for slowing-down functions
- Bux fix regarding ||LF|| in solveInverseProblem.jl
- Plots of solveInverseProblem.jl results will now include a plot of the curvature of the L-curve
- If the L-curve curvature is found to be non-robust, the minimum of abs(||S-WF|| - ||LF||) will be used to find a balanced solution instead of the point of maximum L-curve curvature