### PR TITLE
Improved magnetic equilibrium robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ scratch.jl
 
 __pycache__/
 
-tests/
+tests/outputs/
+
+tests/errors/

--- a/apps/EpRzWebApp.jl
+++ b/apps/EpRzWebApp.jl
@@ -25,7 +25,7 @@
 #### Saved files
 # -
 
-# Script written by Henrik Järleblad and Andrea Valentini. Last maintained 2022-08-25.
+# Script written by Henrik Järleblad and Andrea Valentini. Last maintained 2025-09-01.
 #########################################################################################
 
 ## --------------------------------------------------------------------------
@@ -63,6 +63,22 @@ else
     # The orbit integration algorithm will try progressively smaller timesteps these number of times
 end
 close(myfile)
+
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+######################################### START OF APP ######################################## 
+######################################### DO NOT CHANGE #######################################
+######################################### ANYTHING BELOW ######################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
 
 ## ------
 # Loading packages
@@ -160,11 +176,14 @@ function extractTopoBounds(topoMap::Array{Float64,2}) # The (E,p) part of the fu
 end
 
 ## ------
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk") 
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb # Declare global scope
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/apps/EpRzWebApp.jl
+++ b/apps/EpRzWebApp.jl
@@ -183,7 +183,7 @@ try
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb # Declare global scope
+    global M; global wall; global jdotb; local myfile # Declare global scope and local scope for variables
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/apps/distrWebApp.jl
+++ b/apps/distrWebApp.jl
@@ -299,7 +299,7 @@ try
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb; global timepoint#; global timepoint_source
+    global M; global wall; global jdotb; global timepoint; local myfile #; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/apps/distrWebApp.jl
+++ b/apps/distrWebApp.jl
@@ -89,7 +89,7 @@
 # Plots.heatmap(Rm_array, pm_array, (F_os_3D[iE,:,:])./maximum(F_os_3D[iE,:,:]), colorbar=true, title="Fast-ion distribution slice  ($(round(maximum(F_os_3D[iE,:,:]), sigdigits=4)) = 1.0)",fillcolor=cgrad([:white, :darkblue, :green, :yellow, :orange, :red]))
 # Plots.scatter!(Rm_scatvals_tb,pm_scatvals_tb,markersize=ms,leg=false,markercolor=:black, xlabel="Rm [m]", ylabel="pm")
 
-# Script written by Henrik Järleblad. Last maintained 2022-08-25.
+# Script written by Henrik Järleblad. Last maintained 2025-08-01.
 ###############################################################################################
 
 ## --------------------------------------------------------------------------
@@ -134,6 +134,22 @@ else
     # The orbit integration algorithm will try progressively smaller timesteps these number of times
 end
 close(myfile)
+
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+######################################### START OF APP ######################################## 
+######################################### DO NOT CHANGE #######################################
+######################################### ANYTHING BELOW ######################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
+###############################################################################################
 
 ## ------
 # Loading packages
@@ -276,11 +292,14 @@ end
 
 ## ----------
 # Loading tokamak equilibrium
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk") 
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb; global timepoint#; global timepoint_source # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb; global timepoint#; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/apps/modeAnalysisWebApp.jl
+++ b/apps/modeAnalysisWebApp.jl
@@ -164,7 +164,7 @@ try
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb # Declare global scope
+    global M; global wall; global jdotb; local myfile # Declare global scope and local scope for variables
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/apps/modeAnalysisWebApp.jl
+++ b/apps/modeAnalysisWebApp.jl
@@ -78,7 +78,7 @@
 #
 # Plots.heatmap(Rm_array,pm_array,resonance,legend=false,xlabel="Rm [m]", ylabel="pm", title="E: $(round(E,digits=3)) keV", fillcolor=cgrad([:white, :darkblue, :green, :yellow, :orange, :red]))
 
-# Script written by Henrik Järleblad. Last maintained 2025-01-23.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 ########################################################################################################
 
 #########################################################################################
@@ -126,6 +126,22 @@ if haskey(extra_kw_args, :max_tries) # To allow compatibility with older OWCF fi
 end
 
 #########################################################################################
+#########################################################################################
+#########################################################################################
+#########################################################################################
+#########################################################################################
+#########################################################################################
+######################################### START OF APP ################################## 
+######################################### DO NOT CHANGE #################################
+######################################### ANYTHING BELOW ################################
+#########################################################################################
+#########################################################################################
+#########################################################################################
+#########################################################################################
+#########################################################################################
+#########################################################################################
+
+#########################################################################################
 # Loading packages
 verbose && println("Loading packages... ")
 using Interact
@@ -141,11 +157,14 @@ include(folderpath_OWCF*"extra/dependencies.jl")
 
 #########################################################################################
 # Loading tokamak equilibrium
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk") 
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb # Declare global scope
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/apps/orbitWebApp.jl
+++ b/apps/orbitWebApp.jl
@@ -25,7 +25,7 @@
 
 # Original script written by Henrik Järleblad. 
 # Animation and GIF-saving tools added by Andrea Valentini.
-# Last maintained 2022-11-12.
+# Last maintained 2025-08-01.
 #########################################################################################
 
 ## --------------------------------------------------------------------------
@@ -50,6 +50,22 @@ extra_kw_args = Dict(:toa => true, :limit_phi => true)
 # toa is 'try only adaptive'
 # limits the number of toroidal turns for orbits
 
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+######################################### START OF APP ####################### 
+######################################### DO NOT CHANGE ######################
+######################################### ANYTHING BELOW #####################
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+
 ## ------
 # Loading packages
 verbose && println("Loading packages... ")
@@ -65,11 +81,14 @@ using WebIO
 include(folderpath_OWCF*"misc/species_func.jl")
 
 ## ------
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk") 
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb # Declare global scope
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/apps/orbitWebApp.jl
+++ b/apps/orbitWebApp.jl
@@ -25,7 +25,7 @@
 
 # Original script written by Henrik Järleblad. 
 # Animation and GIF-saving tools added by Andrea Valentini.
-# Last maintained 2025-08-01.
+# Last maintained 2025-09-01.
 #########################################################################################
 
 ## --------------------------------------------------------------------------
@@ -88,7 +88,7 @@ try
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb # Declare global scope
+    global M; global wall; global jdotb; local myfile # Declare global scope and local scope for variables
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/apps/orbitsWebApp.jl
+++ b/apps/orbitsWebApp.jl
@@ -51,7 +51,7 @@
 # iE = argmin(abs.(E_array - E)) # Find the closest value to E in E_array
 # Plots.heatmap(Rm_array,pm_array,topoMap[iE,:,:],color=:Set1_9,legend=false,xlabel="Rm [m]", ylabel="pm", title="E: $(round(E,digits=3)) keV")
 
-# Script written by Henrik Järleblad. Last maintained 2025-01-22.
+# Script written by Henrik Järleblad. Last maintained 2025-08-01.
 #########################################################################################
 
 ## --------------------------------------------------------------------------
@@ -96,6 +96,22 @@ if haskey(extra_kw_args, :max_tries)
     delete!(extra_kw_args, :max_tries)
 end
 
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+######################################### START OF APP ####################### 
+######################################### DO NOT CHANGE ######################
+######################################### ANYTHING BELOW #####################
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+##############################################################################
+
 ## --------------------------------------------------------------------------
 # Loading packages
 verbose && println("Loading packages... ")
@@ -116,11 +132,14 @@ include(folderpath_OWCF*"extra/dependencies.jl")
 
 ## --------------------------------------------------------------------------
 # Loading tokamak equilibrium
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk") 
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb # Declare global scope 
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/apps/orbitsWebApp.jl
+++ b/apps/orbitsWebApp.jl
@@ -51,7 +51,7 @@
 # iE = argmin(abs.(E_array - E)) # Find the closest value to E in E_array
 # Plots.heatmap(Rm_array,pm_array,topoMap[iE,:,:],color=:Set1_9,legend=false,xlabel="Rm [m]", ylabel="pm", title="E: $(round(E,digits=3)) keV")
 
-# Script written by Henrik Järleblad. Last maintained 2025-08-01.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 #########################################################################################
 
 ## --------------------------------------------------------------------------
@@ -139,7 +139,7 @@ try
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb # Declare global scope 
+    global M; global wall; global jdotb; local myfile # Declare global scope 
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/apps/weightsWebApp.jl
+++ b/apps/weightsWebApp.jl
@@ -124,7 +124,7 @@
 
 # Furthermore, the filepath_W_COM input variable can be either an output of this weightsWebApp.jl script, or the os2com.jl script.
 
-# Script written by Henrik Järleblad and Andrea Valentini. Last maintained 2025-08-01.
+# Script written by Henrik Järleblad and Andrea Valentini. Last maintained 2025-09-01.
 ###############################################################################################
 
 ## --------------------------------------------------------------------------
@@ -293,7 +293,7 @@ try
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb # Declare global scope
+    global M; global wall; global jdotb; local myfile # Declare global scope
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/apps/weightsWebApp.jl
+++ b/apps/weightsWebApp.jl
@@ -124,7 +124,7 @@
 
 # Furthermore, the filepath_W_COM input variable can be either an output of this weightsWebApp.jl script, or the os2com.jl script.
 
-# Script written by Henrik Järleblad and Andrea Valentini. Last maintained 2025-03-25.
+# Script written by Henrik Järleblad and Andrea Valentini. Last maintained 2025-08-01.
 ###############################################################################################
 
 ## --------------------------------------------------------------------------
@@ -164,8 +164,19 @@ ylabel = "" # Example neutron count: "Neutron count [(keV*s)^-1]". Example proje
 verbose = true
 
 ########################################################################################################
-# WEB APPLICATION BEGINS BELOW. DO NOT ALTER ANY CODE BELOW THIS LINE!
 ########################################################################################################
+########################################################################################################
+########################################################################################################
+########################################################################################################
+########################################################################################################
+############### WEB APPLICATION BEGINS BELOW. DO NOT ALTER ANY CODE BELOW THIS LINE! ###################
+########################################################################################################
+########################################################################################################
+########################################################################################################
+########################################################################################################
+########################################################################################################
+########################################################################################################
+
 # Must load JLD2 package first, to be able to check filepath_tm and filepath_W for 'extra_kw_args'
 using JLD2
 # EXTRA KEYWORD ARGUMENTS BELOW (these will go into the orbit_grid() and get_orbit() functions from GuidingCenterOrbits.jl)
@@ -275,11 +286,14 @@ end
 
 ## ------
 # Loading tokamak equilibrium
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk") 
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb # Declare global scope
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/calc2DWeights.jl
+++ b/calc2DWeights.jl
@@ -86,7 +86,7 @@
 # Please note that the diagnostic energy grid will be created as bin centers.
 # That is, the first diagnostic energy grid value will be (Ed_min+Ed_diff/2) and so on.
 
-# Script written by Henrik Järleblad. Last maintained 2025-07-11.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 ################################################################################################
 
 ## ---------------------------------------------------------------------------------------------
@@ -260,7 +260,7 @@ try
         timepoint_source, timepoint = "UNKNOWN", "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
     end
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb; global timepoint_source; global timepoint
+    global M; global wall; global jdotb; global timepoint_source; global timepoint; local myfile
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/calc2DWeights.jl
+++ b/calc2DWeights.jl
@@ -239,8 +239,10 @@ end
 # Loading tokamak equilibrium and timepoint
 timepoint_start = deepcopy(timepoint) # Keep timepoint value set in start file
 
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk")
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 
@@ -252,12 +254,13 @@ if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))
         YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
         timepoint = "$(XX*","*YYYY)" # Format XX,YYYY to avoid "." when including in filename of saved output
         timepoint_source = "EQDSK"
-        verbose && println("---> Found timepoint data in .eqdsk file! Loading... ")
+        verbose && println("---> Found timepoint data in magnetic equilibrium file! Loading... ")
     catch
         global timepoint; global timepoint_source # Declare global scope
         timepoint_source, timepoint = "UNKNOWN", "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
     end
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb; global timepoint_source; global timepoint
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/calc4DWeights.jl
+++ b/calc4DWeights.jl
@@ -122,7 +122,7 @@
 # WARNING! Please note that the output files of calc4DWeights.jl will be LARGE. This is due to the relatively high dimensionality
 # of the weight functions.
 
-# Script written by Henrik Järleblad. Last maintained 2025-07-30.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 ################################################################################################
 
 ## ---------------------------------------------------------------------------------------------
@@ -251,24 +251,30 @@ end
 @everywhere tokamak = $tokamak
 
 ## ---------------------------------------------------------------------------------------------
-# Loading tokamak equilibrium
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk")
+# Loading magnetic equilibrium
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 
     # Extract timepoint information from .eqdsk/.geqdsk file
     eqdsk_array = split(filepath_equil,".")
     try
-        global timepoint # Declare global scope
+        global timepoint#; global timepoint_source # Declare global scope
         XX = (split(eqdsk_array[end-2],"-"))[end] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
         YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
-        timepoint = XX*","*YYYY # Format XX,YYYY to avoid "." when including in filename of saved output
+        timepoint = "$(XX*","*YYYY)" # Format XX,YYYY to avoid "." when including in filename of saved output
+        #timepoint_source = "EQDSK"
+        verbose && println("---> Found timepoint data in magnetic equilibrium file! Loading... ")
     catch
-        global timepoint # Declare global scope
-        timepoint = "00,0000" # Unknown timepoint for magnetic equilibrium
+        global timepoint#; global timepoint_source # Declare global scope
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
     end
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb; global timepoint#; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]
@@ -276,9 +282,11 @@ else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
     jdotb = (M.sigma_B0)*(M.sigma_Ip)
 
     if typeof(timepoint)==String && length(split(timepoint,","))==2
-        timepoint = timepoint
+        timepoint = timepoint # (SOURCE, VALUE)
+        #timepoint_source = "STARTFILE"
     else
-        timepoint = "00,0000" # Unknown timepoint for magnetic equilibrium
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
     end
 end
 psi_axis, psi_bdry = psi_limits(M)

--- a/calc4DWeights.jl
+++ b/calc4DWeights.jl
@@ -274,7 +274,7 @@ try
         #timepoint_source = "UNKNOWN"
     end
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb; global timepoint#; global timepoint_source
+    global M; global wall; global jdotb; global timepoint; local myfile #; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/calcEpRzTopoMap.jl
+++ b/calcEpRzTopoMap.jl
@@ -109,7 +109,7 @@ try
         #timepoint_source = "UNKNOWN"
     end
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb; global timepoint#; global timepoint_source
+    global M; global wall; global jdotb; global timepoint; local myfile #; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/calcEpRzTopoMap.jl
+++ b/calcEpRzTopoMap.jl
@@ -66,7 +66,7 @@
 # If saveXYZJacobian==true,
 #   jacobian - The Jacobian from (x,y,z,vx,vy,vz) to (E,p,R,z) for all (E,p,R,z) points - Array{Float64,4}
 
-# Script written by Henrik Järleblad. Last maintained 2025-06-13.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 ########################################################################################
 
 ## ------
@@ -87,21 +87,29 @@ end
 
 ## ------
 # Loading tokamak equilibrium
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk")
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 
     # Extract timepoint information from .eqdsk/.geqdsk file
     eqdsk_array = split(filepath_equil,".")
-    if length(eqdsk_array)>2
+    try
+        global timepoint#; global timepoint_source 
         XX = (split(eqdsk_array[end-2],"-"))[end] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
         YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
-        timepoint = XX*","*YYYY # Format XX,YYYY to avoid "." when including in filename of saved output
-    else
-        timepoint = "00,0000"
+        timepoint = "$(XX*","*YYYY)" # Format XX,YYYY to avoid "." when including in filename of saved output
+        #timepoint_source = "EQDSK"
+        verbose && println("---> Found timepoint data in magnetic equilibrium file! Loading... ")
+    catch
+        global timepoint#; global timepoint_source 
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
     end
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb; global timepoint#; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]
@@ -109,9 +117,11 @@ else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
     jdotb = (M.sigma_B0)*(M.sigma_Ip)
 
     if typeof(timepoint)==String && length(split(timepoint,","))==2
-        timepoint = timepoint
+        timepoint = timepoint # (SOURCE, VALUE)
+        #timepoint_source = "STARTFILE"
     else
-        timepoint = "00,0000" # Unknown timepoint for magnetic equilibrium
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
     end
 end
 

--- a/calcOrbWeights.jl
+++ b/calcOrbWeights.jl
@@ -71,7 +71,7 @@
 # Please note that the diagnostic energy grid will be created as bin centers.
 # That is, the first diagnostic energy grid value will be (Ed_min+Ed_diff/2) and so on.
 
-# Script written by Henrik Järleblad. Last maintained 2025-07-11.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 ################################################################################################
 
 ## ---------------------------------------------------------------------------------------------
@@ -219,17 +219,29 @@ end
 
 ## ---------------------------------------------------------------------------------------------
 # Loading magnetic equilibrium and deduce timepoint, if possible
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk")
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 
     # Extract timepoint information from .eqdsk/.geqdsk file
     eqdsk_array = split(filepath_equil,".")
-    XX = (split(eqdsk_array[end-2],"-"))[end] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
-    YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
-    timepoint = XX*","*YYYY # Format XX,YYYY to avoid "." when including in filename of saved output
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    try
+        global timepoint#; global timepoint_source # Declare global scope
+        XX = (split(eqdsk_array[end-2],"-"))[end] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
+        YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
+        timepoint = "$(XX*","*YYYY)" # Format XX,YYYY to avoid "." when including in filename of saved output
+        #timepoint_source = "EQDSK"
+        verbose && println("---> Found timepoint data in magnetic equilibrium file! Loading... ")
+    catch
+        global timepoint#; global timepoint_source # Declare global scope
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
+    end
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb; global timepoint#; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]
@@ -237,9 +249,11 @@ else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
     jdotb = (M.sigma_B0)*(M.sigma_Ip)
 
     if typeof(timepoint)==String && length(split(timepoint,","))==2
-        timepoint = timepoint
+        timepoint = timepoint # (SOURCE, VALUE)
+        #timepoint_source = "STARTFILE"
     else
-        timepoint = "TIMELESS" # Unknown timepoint for magnetic equilibrium
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
     end
 end
 psi_axis, psi_bdry = psi_limits(M) # The limits of the flux function

--- a/calcOrbWeights.jl
+++ b/calcOrbWeights.jl
@@ -241,7 +241,7 @@ try
         #timepoint_source = "UNKNOWN"
     end
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb; global timepoint#; global timepoint_source
+    global M; global wall; global jdotb; global timepoint; local myfile #; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/calcSpec.jl
+++ b/calcSpec.jl
@@ -281,7 +281,7 @@ try
         #timepoint_source = "UNKNOWN"
     end
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb; global timepoint#; global timepoint_source
+    global M; global wall; global jdotb; global timepoint; local myfile #; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/calcSpec.jl
+++ b/calcSpec.jl
@@ -75,7 +75,7 @@
 # Finally, this script has many 'if' statements and I would expect it to be able to be
 # optimized beyond its current state. This will be done in future version of the OWCF.
 
-# Script written by Henrik Järleblad. Last maintained 2025-07-11.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 ################################################################################################
 
 ## ---------------------------------------------------------------------------------------------
@@ -259,17 +259,29 @@ end
 
 ## ---------------------------------------------------------------------------------------------
 # Loading tokamak equilibrium
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk")
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 
     # Extract timepoint information from .eqdsk/.geqdsk file
     eqdsk_array = split(filepath_equil,".")
-    XX = (split(eqdsk_array[end-2],"-"))[end] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
-    YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
-    timepoint = XX*","*YYYY # Format XX,YYYY to avoid "." when including in filename of saved output
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    try
+        global timepoint#; global timepoint_source # Declare global scope
+        XX = (split(eqdsk_array[end-2],"-"))[end] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
+        YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
+        timepoint = "$(XX*","*YYYY)" # Format XX,YYYY to avoid "." when including in filename of saved output
+        #timepoint_source = "EQDSK"
+        verbose && println("---> Found timepoint data in magnetic equilibrium file! Loading... ")
+    catch
+        global timepoint#; global timepoint_source # Declare global scope
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
+    end
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb; global timepoint#; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]
@@ -277,9 +289,11 @@ else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
     jdotb = (M.sigma_B0)*(M.sigma_Ip)
 
     if typeof(timepoint)==String && length(split(timepoint,","))==2
-        timepoint = timepoint
+        timepoint = timepoint # (SOURCE, VALUE)
+        #timepoint_source = "STARTFILE"
     else
-        timepoint = "00,0000" # Unknown timepoint for magnetic equilibrium
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
     end
 end
 psi_axis, psi_bdry = psi_limits(M)

--- a/calcTopoMap.jl
+++ b/calcTopoMap.jl
@@ -101,7 +101,7 @@ try
         #timepoint_source = "UNKNOWN"
     end
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb; global timepoint#; global timepoint_source
+    global M; global wall; global jdotb; global timepoint; local myfile #; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/calcTopoMap.jl
+++ b/calcTopoMap.jl
@@ -57,7 +57,7 @@
 # Please note, because of numerical reasons, all integers (1,2,3,4,5,6,7,8,9) will actually be saved as 
 # their Float64 counterparts (1.0, 2.0 etc).
 
-# Script written by Henrik Järleblad. Last maintained 2023-01-09.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 #######################################################################################################
 
 ## ------
@@ -79,21 +79,29 @@ end
 
 ## ------
 # Loading tokamak equilibrium
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk")
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
+try
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 
     # Extract timepoint information from .eqdsk/.geqdsk file
     eqdsk_array = split(filepath_equil,".")
-    if length(eqdsk_array)>2
+    try
+        global timepoint#; global timepoint_source # Declare global scope
         XX = (split(eqdsk_array[end-2],"-"))[end] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
         YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
-        timepoint = XX*","*YYYY # Format XX,YYYY to avoid "." when including in filename of saved output
-    else
-        timepoint = "00,0000"
+        timepoint = "$(XX*","*YYYY)" # Format XX,YYYY to avoid "." when including in filename of saved output
+        #timepoint_source = "EQDSK"
+        verbose && println("---> Found timepoint data in magnetic equilibrium file! Loading... ")
+    catch
+        global timepoint#; global timepoint_source # Declare global scope
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
     end
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall; global jdotb; global timepoint#; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]
@@ -101,9 +109,11 @@ else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
     jdotb = (M.sigma_B0)*(M.sigma_Ip)
 
     if typeof(timepoint)==String && length(split(timepoint,","))==2
-        timepoint = timepoint
+        timepoint = timepoint # (SOURCE, VALUE)
+        #timepoint_source = "STARTFILE"
     else
-        timepoint = "00,0000" # Unknown timepoint for magnetic equilibrium
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
     end
 end
 

--- a/extra/createCustomFIDistr.jl
+++ b/extra/createCustomFIDistr.jl
@@ -133,9 +133,12 @@ if constant_Rz
         if filepath_thermal_profiles==""
             filepath_thermal_profiles="nothing" # Change to "nothing" for code convenience reasons
         end
-        if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk")
+        M, wall = nothing, nothing # Initialize equilibrium variables
+        try
+            global M; global wall
             M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
-        else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+        catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+            global M; global wall; local myfile
             myfile = jldopen(filepath_equil,false,false,false,IOStream)
             M, wall = myfile["S"], myfile["wall"]
             close(myfile)

--- a/extra/createCustomLOS.jl
+++ b/extra/createCustomLOS.jl
@@ -119,7 +119,7 @@ try
     global M; global wall
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall
+    global M; global wall; local myfile
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M, wall = myfile["S"], myfile["wall"]
     close(myfile)

--- a/extra/createCustomLOS.jl
+++ b/extra/createCustomLOS.jl
@@ -52,7 +52,7 @@
 # - The tenth column corresponds to toroidal phi angle points
 # - The eleventh column corresponds to solid angles OMEGA
 
-# Script written by Henrik Järleblad. Last maintained 2025-06-03.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 ###############################################################################################################
 
 ## ---------------------------------------------------------------------------------------------
@@ -63,9 +63,8 @@ println("Loading Julia packages... ")
     using JLD2
     using LinearAlgebra
     using Equilibrium
-    plot_LOS && (using Plots)
+    using Plots
     debug = debug # This is always set to false, except when OWCF developers are debugging
-    debug && (using Plots)
 end
 
 ## ---------------------------------------------------------------------------------------------
@@ -114,10 +113,13 @@ end
 verbose && println("It's $(case)!")
 ## ---------------------------------------------------------------------------------------------
 # Loading tokamak equilibrium
-verbose && println("Loading tokamak equilibrium... ")
-if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk")
+verbose && println("Loading magnetic equilibrium... ")
+M, wall = nothing, nothing # Initialize equilibrium variables
+try
+    global M; global wall
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
-else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    global M; global wall
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M, wall = myfile["S"], myfile["wall"]
     close(myfile)

--- a/extra/dependencies.jl
+++ b/extra/dependencies.jl
@@ -2443,10 +2443,10 @@ function ps2os_streamlined(F_EpRz::Array{Float64,4}, energy::AbstractVector, pit
                            numOsamples::Int64, verbose::Bool=false, distr_dim = [], sign_o_pitch_wrt_B::Bool=false, clockwise_phi::Bool=false, kwargs...)
 
     verbose && println("Loading the magnetic equilibrium... ")
-    if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk")
+    try
         M, wall = read_geqdsk(filepath_equil,clockwise_phi=clockwise_phi) # Assume counter-clockwise phi-direction
         jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
-    else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
         myfile = jldopen(filepath_equil,false,false,false,IOStream)
         M = myfile["S"]
         wall = myfile["wall"]

--- a/ps2WF.jl
+++ b/ps2WF.jl
@@ -101,7 +101,7 @@
 # script will then resume at the last checkpoint, and continue until the script is finished.
 # The progress file is then deleted once ps2WF.jl completes successfully.
 
-# Script written by Henrik Järleblad. Last maintained 2025-07-11.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 ################################################################################################
 
 
@@ -242,20 +242,28 @@ end
 
 ## ---------------------------------------------------------------------------------------------
 # Loading tokamak equilibrium
-verbose && println("Loading tokamak equilibrium... ")
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
 try
-    global M; global wall; global jdotb; global timepoint; global timepoint_source
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 
     # Extract timepoint information from .eqdsk/.geqdsk file
     eqdsk_array = split(filepath_equil,".")
-    XX = (split(eqdsk_array[end-2],"-"))[end] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
-    YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
-    timepoint_source = "EQDSK"
-    timepoint = XX*","*YYYY # (SOURCE, VALUE). Format XX,YYYY to avoid "." when including in filename of saved output
+    try
+        global timepoint; global timepoint_source # Declare global scope
+        XX = (split(eqdsk_array[end-2],"-"))[end] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
+        YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
+        timepoint = "$(XX*","*YYYY)" # Format XX,YYYY to avoid "." when including in filename of saved output
+        timepoint_source = "EQDSK"
+        verbose && println("---> Found timepoint data in magnetic equilibrium file! Loading... ")
+    catch
+        global timepoint; global timepoint_source # Declare global scope
+        timepoint_source, timepoint = "UNKNOWN", "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+    end
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb; global timepoint; local myfile; global timepoint_source
+    global M; global wall; global jdotb; global timepoint_source; global timepoint
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/ps2WF.jl
+++ b/ps2WF.jl
@@ -263,7 +263,7 @@ try
         timepoint_source, timepoint = "UNKNOWN", "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
     end
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb; global timepoint_source; global timepoint
+    global M; global wall; global jdotb; global timepoint_source; global timepoint; local myfile
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/ps2os.jl
+++ b/ps2os.jl
@@ -65,7 +65,7 @@
 # Please note that in future versions of the OWCF, the user may use a toggle input to select other transformation methods
 # than simply Monte-Carlo methods. This has, however, not yet been incorporated into the OWCF.
 #
-# Script written by Henrik Järleblad. Last maintained 2025-05-07.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 ##################################################################################################################################
 
 ## --------------------------------------------------------------------------------------
@@ -103,26 +103,42 @@ end
 ## --------------------------------------------------------------------------------------
 # Loading tokamak equilibrium and format timepoint information
 ## --------------------------------------------------------------------------------------
-verbose && println("Loading tokamak equilibrium... ")
+verbose && println("Loading magnetic equilibrium... ")
+M, wall, jdotb = nothing, nothing, nothing # Initialize global magnetic equilibrium variables
 try
-    global M; global wall; global jdotb; global timepoint
+    global M; global wall; global jdotb # Declare global scope
     M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
     jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 
     # Extract timepoint information from .eqdsk/.geqdsk file
-    if isnothing(timepoint)
-        eqdsk_array = split(filepath_equil,".")
+    eqdsk_array = split(filepath_equil,".")
+    try
+        global timepoint#; global timepoint_source # Declare global scope
         XX = (split(eqdsk_array[end-2],"-"))[end] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
         YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
-        timepoint = XX*","*YYYY # Format XX,YYYY to avoid "." when including in filename of saved output
+        timepoint = "$(XX*","*YYYY)" # Format XX,YYYY to avoid "." when including in filename of saved output
+        #timepoint_source = "EQDSK"
+        verbose && println("---> Found timepoint data in magnetic equilibrium file! Loading... ")
+    catch
+        global timepoint#; global timepoint_source # Declare global scope
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
     end
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb
+    global M; global wall; global jdotb; global timepoint#; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]
     close(myfile)
     jdotb = (M.sigma_B0)*(M.sigma_Ip)
+
+    if typeof(timepoint)==String && length(split(timepoint,","))==2
+        timepoint = timepoint # (SOURCE, VALUE)
+        #timepoint_source = "STARTFILE"
+    else
+        timepoint = "00,0000" # (SOURCE, VALUE). Unknown timepoint for magnetic equilibrium
+        #timepoint_source = "UNKNOWN"
+    end
 end
 if typeof(timepoint)==String
     timepoint = replace(timepoint, "." => ",")

--- a/ps2os.jl
+++ b/ps2os.jl
@@ -125,7 +125,7 @@ try
         #timepoint_source = "UNKNOWN"
     end
 catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-    global M; global wall; global jdotb; global timepoint#; global timepoint_source
+    global M; global wall; global jdotb; global timepoint; local myfile #; global timepoint_source
     myfile = jldopen(filepath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]

--- a/solveInverseProblem.jl
+++ b/solveInverseProblem.jl
@@ -742,7 +742,7 @@ if "collisions" in lowercase.(String.(regularization))
         global M; global wall # Declare global scope
         M, wall = read_geqdsk(regularization_equil_filepath,clockwise_phi=false) # Assume the phi-direction is pointing counter-clockwise when tokamak is viewed from above. This is true for almost all coordinate systems used in the field of plasma physics
     catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-        global M; global wall
+        global M; global wall; local myfile
         myfile = jldopen(regularization_equil_filepath,false,false,false,IOStream)
         M = myfile["S"]
         wall = myfile["wall"]
@@ -1231,7 +1231,7 @@ if "icrf" in lowercase.(String.(regularization))
         global M; global wall # Declare global scope
         M, wall = read_geqdsk(regularization_equil_filepath,clockwise_phi=false) # Assume the phi-direction is pointing counter-clockwise when tokamak is viewed from above. This is true for almost all coordinate systems used in the field of plasma physics
     catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
-        global M; global wall
+        global M; global wall; local myfile
         myfile = jldopen(regularization_equil_filepath,false,false,false,IOStream)
         M = myfile["S"]
         wall = myfile["wall"]

--- a/solveInverseProblem.jl
+++ b/solveInverseProblem.jl
@@ -92,7 +92,7 @@
 ### Other
 # 
 
-# Script written by Henrik Järleblad. Last maintained 2025-07-30.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 ###########################################################################################################
 
 # A dictionary to keep a record of the names of all sections and their respective execution times
@@ -737,7 +737,17 @@ if "collisions" in lowercase.(String.(regularization))
     end
     verbose && println("ok!")
     verbose && print("---> Loading magnetic equilibrium from $(regularization_equil_filepath)... ")
-    M, wall = read_geqdsk(regularization_equil_filepath,clockwise_phi=false) # Assume the phi-direction is pointing counter-clockwise when tokamak is viewed from above. This is true for almost all coordinate systems used in the field of plasma physics
+    M, wall = nothing, nothing # Initialize global magnetic equilibrium variables
+    try
+        global M; global wall # Declare global scope
+        M, wall = read_geqdsk(regularization_equil_filepath,clockwise_phi=false) # Assume the phi-direction is pointing counter-clockwise when tokamak is viewed from above. This is true for almost all coordinate systems used in the field of plasma physics
+    catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+        global M; global wall
+        myfile = jldopen(regularization_equil_filepath,false,false,false,IOStream)
+        M = myfile["S"]
+        wall = myfile["wall"]
+        close(myfile)
+    end
     psi_axis, psi_bdry = psi_limits(M)
     verbose && println("ok!")
 
@@ -1215,7 +1225,18 @@ if "icrf" in lowercase.(String.(regularization))
     verbose && println("ok!")
 
     verbose && print("---> Loading magnetic equilibrium from $(regularization_equil_filepath)... ")
-    M, wall = read_geqdsk(regularization_equil_filepath,clockwise_phi=false) # Assume the phi-direction is pointing counter-clockwise when tokamak is viewed from above. This is true for almost all coordinate systems used in the field of plasma physics
+    verbose && println("Loading magnetic equilibrium... ")
+    M, wall = nothing, nothing # Initialize global magnetic equilibrium variables
+    try
+        global M; global wall # Declare global scope
+        M, wall = read_geqdsk(regularization_equil_filepath,clockwise_phi=false) # Assume the phi-direction is pointing counter-clockwise when tokamak is viewed from above. This is true for almost all coordinate systems used in the field of plasma physics
+    catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+        global M; global wall
+        myfile = jldopen(regularization_equil_filepath,false,false,false,IOStream)
+        M = myfile["S"]
+        wall = myfile["wall"]
+        close(myfile)
+    end
     psi_axis, psi_bdry = psi_limits(M)
     verbose && println("ok!")
 
@@ -1481,7 +1502,7 @@ for ir in eachindex(priors) # For all regularizations/priors that require a hype
         loglambda_min = regularization_loglambda_mins[iir]
         loglambda_max = regularization_loglambda_maxs[iir]
     end
-    append!(hyper_arrays,[10 .^(range(loglambda_min,stop=loglambda_max,length=nr))])
+    append!(hyper_arrays,[10 .^(range(Float64(loglambda_min),stop=Float64(loglambda_max),length=Int64(nr)))])
     verbose && println("---> $(priors_name[ir]) with $(nr) λ grid points between 10^$(loglambda_min) and 10^$(loglambda_max)... ")
 end
 hyper_points = Iterators.product(hyper_arrays...)
@@ -1504,12 +1525,16 @@ collision_physics_reg = false
 if "collisions" in lowercase.(String.(regularization))
     collision_physics_reg = true # Just a bool to speed up computations
 end
-
 verbose && println("")
+
+if verbose
+    verbose_onlyForSolve = true # If verbose is true, so is verbose_onlyForSolve
+end
+
 nip = length(hyper_points); s = nip>1 ? "s" : ""
-verbose && println("Solving $(nip) inverse problem$(s) (each with $(size(W_hh,2)) unknowns and $(size(W_hh,1)) measurements)... ")
+verbose_onlyForSolve && println("Solving $(nip) inverse problem$(s) (each with $(size(W_hh,2)) unknowns and $(size(W_hh,1)) measurements)... ")
 for (i,hp) in enumerate(hyper_points)
-    verbose && println("---> ($(i)/$(nip)) for regularization hyper-parameter point $(round.(vcat(hp...),sigdigits=4)) ($([pn for pn in priors_name]))... ")
+    verbose_onlyForSolve && println("---> ($(i)/$(nip)) for regularization hyper-parameter point $(round.(vcat(hp...),sigdigits=4)) ($([pn for pn in priors_name]))... ")
     L_i = Matrix(vcat((vcat(hp...) .*L)...)) # Multiply hyper-parameter values with the corresponding regularization matrices. Then, concatenate into one big regularization matrix
     x = Convex.Variable(size(W_hh,2))
 

--- a/templates/start_solveInverseProblem_template.jl
+++ b/templates/start_solveInverseProblem_template.jl
@@ -214,7 +214,8 @@
 #                   calcOrbWeights.jl. This is to enable easy I/O between OWCF scripts. If a file in filepaths_W was NOT 
 #                   computed with the OWCF, just put 'none' for the corresponding element in scriptSources_W.
 # tokamak - The tokamak for which the inverse problem is solved. E.g. JET, ITER etc. Will be used purelely for esthetic purposes. - String
-# verbose - If set to true, the script will talk a lot! - Bool
+# verbose - If set to true, the script will talk a lot when running all parts of solveInverseProblem.jl! - Bool
+# verbose_onlyForSolve - If set to true, the script will talk a lot, but only when actually solving the minimization problem - Bool
 # z_of_interest - If the reconstruction is in velocity-space (2D), an (R,z) point of interest might need to be specified, to 
 #                 e.g. include collision physics or ICRF as prior information, or to rescale the weight functions using a reference fast-ion distribution.
 #                 Otherwise, please leave unspecified - Float64
@@ -230,7 +231,7 @@
 # Some lines below are commented out. This is because the inverse problem solving algorithm is currently single-CPU.
 # In future version, multi-core processing might be supported, and those lines will then be uncommented.
 
-# Script written by Henrik Järleblad. Last maintained 2025-07-30.
+# Script written by Henrik Järleblad. Last maintained 2025-08-01.
 #############################################################################################################################################################
 
 ## First you have to set the system specifications
@@ -327,6 +328,7 @@ Pkg.activate(".")
     scriptSources_W = ["",""]
     tokamak = ""
     verbose = false
+    verbose_onlyForSolve = false
     z_of_interest = nothing
     z_of_interest_units = "m"
 

--- a/templates/start_solveInverseProblem_template.jl
+++ b/templates/start_solveInverseProblem_template.jl
@@ -231,7 +231,7 @@
 # Some lines below are commented out. This is because the inverse problem solving algorithm is currently single-CPU.
 # In future version, multi-core processing might be supported, and those lines will then be uncommented.
 
-# Script written by Henrik Järleblad. Last maintained 2025-08-01.
+# Script written by Henrik Järleblad. Last maintained 2025-09-01.
 #############################################################################################################################################################
 
 ## First you have to set the system specifications

--- a/tests/run_tests.jl
+++ b/tests/run_tests.jl
@@ -53,7 +53,7 @@
 # files, if plot_test_results==true). These will be saved in the OWCF/tests/outputs/ folder. The 
 # total size of all data files and .png figure files will be in the range of tens of megabytes.
 
-# Script written by Henrik Järleblad. Last mainted 2025-06-11.
+# Script written by Henrik Järleblad. Last mainted 2025-09-01.
 ###################################################################################################
 
 # Inputs. To be switched freely between 'true' and 'false'
@@ -350,6 +350,8 @@ end
 t_end = time() # Test script runtime end
 println("-------------------------------------------------------------------------------- End of the OWCF tests")
 println("-------------------------------------------------------------------------------- Total runtime: $(Int64(divrem(t_end-t_start,60)[1])) minutes $(Int64(round(divrem(t_end-t_start,60)[2]))) seconds")
+date_and_time = split("$(Dates.now())","T")[1]*" at "*split("$(Dates.now())","T")[2][1:5]
+println("-------------------------------------------------------------------------------- Current date and time: $(date_and_time)")
 println("-------------------------------------------------------------------------------- OWCF folder path: $(folderpath_OWCF)")
 println("-------------------------------------------------------------------------------- The OWCF tests --------------------------------------------------------------------------------")
 ###------------------------------------------------------------------------------------------------###

--- a/tutorials/compute_beam_neutron_spectrum.jl
+++ b/tutorials/compute_beam_neutron_spectrum.jl
@@ -58,6 +58,7 @@ if !(filepath_equil=="")
         YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
         timepoint = XX*","*YYYY # Format XX,YYYY to avoid "." when including in filename of saved output
     catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+        global M; global wall; global jdotb; global timepoint; local myfile
         myfile = jldopen(filepath_equil,false,false,false,IOStream)
         M = myfile["S"]
         wall = myfile["wall"]

--- a/tutorials/compute_beam_neutron_spectrum.jl
+++ b/tutorials/compute_beam_neutron_spectrum.jl
@@ -45,8 +45,10 @@ B_vec = [0.0, -2.7, 0.0] # Teslas
 # In this section, if you have specified the 'filepath_equil' variable, the magnetic equilibrium 
 # is loaded and plotted.
 if !(filepath_equil=="")
-    verbose && println("Loading tokamak equilibrium... ")
-    if ((split(filepath_equil,"."))[end] == "eqdsk") || ((split(filepath_equil,"."))[end] == "geqdsk")
+    verbose && println("Loading magnetic equilibrium... ")
+    M, wall, jdotb, timepoint = nothing, nothing, nothing, nothing # Initialize equilibrium variables
+    try
+        global M; global wall; global jdotb; global timepoint
         M, wall = read_geqdsk(filepath_equil,clockwise_phi=false) # Assume counter-clockwise phi-direction
         jdotb = M.sigma # The sign of the dot product between the plasma current and the magnetic field
 
@@ -55,7 +57,7 @@ if !(filepath_equil=="")
         XX = (split(eqdsk_array[end-2],"-"))[end] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
         YYYY = eqdsk_array[end-1] # Assume format ...-XX.YYYY.eqdsk where XX are the seconds and YYYY are the decimals
         timepoint = XX*","*YYYY # Format XX,YYYY to avoid "." when including in filename of saved output
-    else # Otherwise, assume magnetic equilibrium is a saved .jld2 file
+    catch # Otherwise, assume magnetic equilibrium is a saved .jld2 file
         myfile = jldopen(filepath_equil,false,false,false,IOStream)
         M = myfile["S"]
         wall = myfile["wall"]

--- a/tutorials/compute_orbits.jl
+++ b/tutorials/compute_orbits.jl
@@ -11,16 +11,27 @@ using Pkg # Then, you load the Pkg.jl package which is Julia's package manager
 Pkg.activate(".") # Then, you activate the virtual environment of the OWCF
 ##############################################################################################################
 using Equilibrium # Then, we load the Equilibrium.jl package, which we use to handle magnetic equilibria
+using JLD2 # To be able to load .jld2 files
 using GuidingCenterOrbits # Then, we load the GuidingCenterOrbits.jl package, which we use to compute fast-ion drift orbits
 using Plots # Then, we load the Plots.jl package, to be able to plot things
 include(folderpath_OWCF*"misc/species_func.jl") # Then, we load OWCF species functions to be able to easily work with different particle species
 ##############################################################################################################
 folderpath_equil = folderpath_OWCF*"equilibrium/JET/g96100/g96100_0-53.0012.eqdsk" # Specify the filepath to a magnetic equilibrium file.
 # The magnetic equilibrium file can be either an .eqdsk file or a .jld2 file obtained from the extra/createCustomMagneticEquilibrium.jl script
-M, wall = read_geqdsk(folderpath_equil, clockwise_phi=false) # Then, we load the magnetic equilibrium into the M variable and the 
-# tokamak wall into the wall variable, via the read_geqdsk() function. We have to specify whether the coordinate system is arranged so as to 
-# have the phi-coordinate in the (R,phi,z) coordinate system point in the clockwise or counter-clockwise direction, viewed from above.
-# Almost all tokamak coordinate systems have phi pointing counter-clockwise, viewed from above
+M, wall = nothing, nothing # Initialize the equilibrium data variables
+try
+    global M; global wall # Declare global scope
+    M, wall = read_geqdsk(folderpath_equil, clockwise_phi=false) # Then, we load the magnetic equilibrium into the M variable and the
+    # tokamak wall into the wall variable, via the read_geqdsk() function. We have to specify whether the coordinate system is arranged so as to 
+    # have the phi-coordinate in the (R,phi,z) coordinate system point in the clockwise or counter-clockwise direction, viewed from above.
+    # Almost all tokamak coordinate systems have phi pointing counter-clockwise, viewed from above
+catch
+    global M; global wall
+    myfile = jldopen(folderpath_equil,false,false,false,IOStream)
+    M = myfile["S"]
+    wall = myfile["wall"]
+    close(myfile)
+end
 ##############################################################################################################
 E = 100.0 # Then, we specify the energy of the fast ion, in keV
 pm = 0.29 # Then, we specify the pitch maximum orbit label of the fast ion

--- a/tutorials/compute_orbits.jl
+++ b/tutorials/compute_orbits.jl
@@ -26,7 +26,7 @@ try
     # have the phi-coordinate in the (R,phi,z) coordinate system point in the clockwise or counter-clockwise direction, viewed from above.
     # Almost all tokamak coordinate systems have phi pointing counter-clockwise, viewed from above
 catch
-    global M; global wall
+    global M; global wall; local myfile
     myfile = jldopen(folderpath_equil,false,false,false,IOStream)
     M = myfile["S"]
     wall = myfile["wall"]


### PR DESCRIPTION
The process for loading magnetic equilibrium data for use by the OWCF tools has been given improved robustness.
Old version:
- Checking for acceptable file extensions
New version:
- Try to load an EQDSK file. If failed, try to load an .jld2 file

In addition, the timepoint data loading process has also been given improved robustness. 

Finally, the solveInverseProblem tool has been given new functionality, in the form of:
- Possibility to specify lower and upper bounds of regularization range
- Possibility to be verbose (print) but only when solving the inverse problem

As can be seen below, the changes pertaining to this pull-request did not result in any errors when running the OWCF tests:
<img width="1801" height="252" alt="Screenshot from 2025-09-01 20-28-52" src="https://github.com/user-attachments/assets/0200b01d-de5b-4169-a65c-21f9768813c5" />

